### PR TITLE
Unmemoized getSchemaReferenceFields

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   name: 'urbanetic:bismuth-schema-utility',
   summary: 'Utilites for schemas and collections in Bismuth.',
   git: 'https://github.com/urbanetic/bismuth-schema-utility.git',
-  version: '0.2.0'
+  version: '0.2.1'
 });
 
 Package.on_use(function(api) {

--- a/src/SchemaUtils.coffee
+++ b/src/SchemaUtils.coffee
@@ -24,16 +24,16 @@ SchemaUtils =
       if fieldSchema?
         callback(fieldSchema, fieldId)
 
-  getSchemaReferenceFields: _.memoize(
-    (collection) ->
-      refFields = {}
-      schema = collection.simpleSchema()
-      Collections.forEachFieldSchema schema, (field, fieldId) ->
-        if field.collectionType
-          refFields[fieldId] = field
-      refFields
-    (collection) -> Collections.getName(collection)
-  )
+  getSchemaReferenceFields: (collection) ->
+    refFields = {}
+    schema = collection.simpleSchema()
+    Collections.forEachFieldSchema schema, (field, fieldId) ->
+      if field.collectionType
+        refFields[fieldId] = field
+    refFields
+
+  getSchemaReferenceFieldsMemoized: (collection) ->
+    _.memoize(SchemaUtils.getSchemaReferenceFields, Collections.getName.bind(Collections))(collection)
 
   getRefModifier: (model, collection, idMaps) ->
     modifier = {}


### PR DESCRIPTION
Added `getSchemaReferenceFieldsMemoized` to retain the old behaviour if preferred. Default behaviour should not memoize in case the schema(s) of a collection changes at runtime (e.g. during tests).
